### PR TITLE
feat: add codepen edit links

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,6 +52,9 @@
       <iframe class="demo-frame" src="examples/vanilla-js/index.html" name="bouncy ball demo" frameborder="1" scrolling="no"></iframe>
     </div>
     <div class="pane source-pane">
+      <div class="edit-toggle">
+        <a class="edit-toggle-link" href="#">Edit on CodePen</a>
+      </div>
       <pre><code class="language-javascript"></code></pre>
     </div>
   </div>

--- a/site/assets/bundle.js
+++ b/site/assets/bundle.js
@@ -10920,7 +10920,7 @@ return Autolinker;
   }
 })();
 
-},{"./docsToggle":64,"./updatePanes":66}],64:[function(require,module,exports){
+},{"./docsToggle":64,"./updatePanes":67}],64:[function(require,module,exports){
 'use strict';
 
 function setup() {
@@ -10935,6 +10935,19 @@ function setup() {
 module.exports = { setup: setup };
 
 },{}],65:[function(require,module,exports){
+'use strict';
+
+module.exports = {
+  'vanilla-js': 'http://codepen.io/team/sparkbox/pen/AXzoGo', // JS
+  'css': 'http://codepen.io/team/sparkbox/pen/yJAomg', // css
+  'jquery': 'http://codepen.io/team/sparkbox/pen/mEgrNg', // jQuery
+  'greensock': 'http://codepen.io/team/sparkbox/pen/oLOpLZ', // Greensock
+  'velocity': 'http://codepen.io/team/sparkbox/pen/OXGzXB', // Velocity
+  'web-animations-api': 'http://codepen.io/team/sparkbox/pen/mEgpAK', // Web Animations API
+  'p5': 'http://codepen.io/team/sparkbox/pen/BzEJLv' // P5.js
+};
+
+},{}],66:[function(require,module,exports){
 'use strict';
 
 function sourceDump(url, dumpLocation, options) {
@@ -10972,12 +10985,13 @@ function sourceDump(url, dumpLocation, options) {
 
 module.exports = sourceDump;
 
-},{}],66:[function(require,module,exports){
+},{}],67:[function(require,module,exports){
 'use strict';
 
 var Prism = require('prismjs'),
     Remarkable = require('remarkable'),
-    sourceDump = require('./sourceDump');
+    sourceDump = require('./sourceDump'),
+    editLinks = require('./editLinks');
 
 /**
  * Updates the preview & source panes based to match the currently selected option.
@@ -10991,12 +11005,16 @@ function updatePanes(event) {
   srcUrl = 'examples/' + selected.id + '/' + srcFileName,
       demoUrl = 'examples/' + selected.id + '/index.html',
       docsUrl = 'examples/' + selected.id + '/readme.md',
+      editUrl = editLinks[selected.id],
 
   // pane elements
   srcEl = document.querySelector('.source-pane > pre > code'),
       demoEl = document.querySelector('.demo-frame'),
       docsEl = document.querySelector('.docs-pane-content'),
+      editEl = document.querySelector('.edit-toggle-link'),
       docsLinkDemoName = document.querySelector('.demo-name');
+
+  console.log(editUrl);
 
   // Update the page URL, when an option is changed.
   // We only do this on the change event to prevent hash updates on initial page load.
@@ -11010,6 +11028,9 @@ function updatePanes(event) {
 
   // Update the demo pane.
   demoEl.setAttribute('src', demoUrl);
+
+  // Update the edit link.
+  editEl.setAttribute('href', editUrl);
 
   // Update the docs pane.
   docsLinkDemoName.textContent = name;
@@ -11039,4 +11060,4 @@ function updatePanes(event) {
 
 module.exports = updatePanes;
 
-},{"./sourceDump":65,"prismjs":1,"remarkable":2}]},{},[63]);
+},{"./editLinks":65,"./sourceDump":66,"prismjs":1,"remarkable":2}]},{},[63]);

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -344,6 +344,23 @@ input[type="radio"]:checked + .label-webanimations {
     min-width: calc(160px - 1.3rem);
   }
   }
+.edit-toggle {
+  position: absolute;
+  top: 8.8px;
+  top: 0.55rem;
+  right: 0;
+  z-index: 1;
+  width: calc(40% - 1.1rem);
+  min-width: calc(160px - 1.1rem)
+}
+@media (min-width: 500px) {
+  .edit-toggle {
+    top: 0.75rem;
+    right: 1.3rem;
+    width: calc(40% - 1.3rem);
+    min-width: calc(160px - 1.3rem);
+  }
+  }
 .docs-toggle-link {
   font-size: 10px;
   color: #e6db74
@@ -353,6 +370,15 @@ input[type="radio"]:checked + .label-webanimations {
 }
 @media (min-width: 500px) {
   .docs-toggle-link {
+    font-size: 13px;
+  }
+  }
+.edit-toggle-link {
+  font-size: 10px;
+  color: #e6db74
+}
+@media (min-width: 500px) {
+  .edit-toggle-link {
     font-size: 13px;
   }
   }
@@ -385,6 +411,7 @@ input[type="radio"]:checked + .label-webanimations {
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
+  position: relative;
   -webkit-box-align: stretch;
       -ms-flex-align: stretch;
           align-items: stretch;
@@ -406,7 +433,7 @@ input[type="radio"]:checked + .label-webanimations {
   border-radius: 0;
   font-size: 0.75em;
   margin: 0;
-  padding: 1.5em 0.5em 0.5em 1.5em;/* note: detailed source code styles are provided by prismjs */
+  padding: 2.5em 0.5em 0.5em 1.5em;/* note: detailed source code styles are provided by prismjs */
 }
 @media (min-width: 900px) {
   .source-pane > pre {

--- a/site/css/styles.css
+++ b/site/css/styles.css
@@ -212,6 +212,21 @@ input[type="radio"] {
   }
 }
 
+.edit-toggle {
+  position: absolute;
+  top: 0.55rem;
+  right: 0;
+  z-index: 1;
+  width: calc(40% - var(--docsLeftPadding));
+  min-width: calc(var(--paneMinWidth) - var(--docsLeftPadding));
+
+  @media (--midphone-plus) {
+    top: 0.75rem;
+    right: var(--docsLeftPaddingMedium);
+    width: calc(40% - var(--docsLeftPaddingMedium));
+    min-width: calc(var(--paneMinWidth) - var(--docsLeftPaddingMedium));
+  }
+}
 .docs-toggle-link {
   font-size: 10px;
   color: var(--linkYellow);
@@ -219,6 +234,15 @@ input[type="radio"] {
   &::before {
     content: 'More '
   }
+
+  @media (--midphone-plus) {
+    font-size: 13px;
+  }
+}
+
+.edit-toggle-link {
+  font-size: 10px;
+  color: var(--linkYellow);
 
   @media (--midphone-plus) {
     font-size: 13px;
@@ -244,6 +268,7 @@ input[type="radio"] {
 
 .source-pane {
   display: flex;
+  position: relative;
   align-items: stretch;
   flex-grow: 1;
   flex-shrink: 1;
@@ -257,7 +282,7 @@ input[type="radio"] {
     border-radius: 0;
     font-size: 0.75em;
     margin: 0;
-    padding: 1.5em 0.5em 0.5em 1.5em;
+    padding: 2.5em 0.5em 0.5em 1.5em;
 
     /* note: detailed source code styles are provided by prismjs */
 

--- a/site/js/editLinks.js
+++ b/site/js/editLinks.js
@@ -1,0 +1,9 @@
+module.exports = {
+  'vanilla-js': 'http://codepen.io/team/sparkbox/pen/AXzoGo', // JS
+  'css': 'http://codepen.io/team/sparkbox/pen/yJAomg', // css
+  'jquery': 'http://codepen.io/team/sparkbox/pen/mEgrNg', // jQuery
+  'greensock': 'http://codepen.io/team/sparkbox/pen/oLOpLZ', // Greensock
+  'velocity': 'http://codepen.io/team/sparkbox/pen/OXGzXB', // Velocity
+  'web-animations-api': 'http://codepen.io/team/sparkbox/pen/mEgpAK', // Web Animations API
+  'p5': 'http://codepen.io/team/sparkbox/pen/BzEJLv'  // P5.js
+};

--- a/site/js/updatePanes.js
+++ b/site/js/updatePanes.js
@@ -1,6 +1,7 @@
 const Prism = require('prismjs'),
       Remarkable = require('remarkable'),
-      sourceDump = require('./sourceDump');
+      sourceDump = require('./sourceDump'),
+      editLinks = require('./editLinks');
 
 /**
  * Updates the preview & source panes based to match the currently selected option.
@@ -13,12 +14,16 @@ function updatePanes(event) {
         srcUrl = 'examples/' + selected.id + '/' + srcFileName,
         demoUrl = 'examples/' + selected.id + '/index.html',
         docsUrl = 'examples/' + selected.id + '/readme.md',
+        editUrl =  editLinks[selected.id],
         // pane elements
         srcEl = document.querySelector('.source-pane > pre > code'),
         demoEl = document.querySelector('.demo-frame'),
         docsEl = document.querySelector('.docs-pane-content'),
+        editEl = document.querySelector('.edit-toggle-link'),
 
         docsLinkDemoName = document.querySelector('.demo-name');
+
+  console.log(editUrl);
 
   // Update the page URL, when an option is changed.
   // We only do this on the change event to prevent hash updates on initial page load.
@@ -32,6 +37,9 @@ function updatePanes(event) {
 
   // Update the demo pane.
   demoEl.setAttribute('src', demoUrl);
+
+  // Update the edit link.
+  editEl.setAttribute('href', editUrl);
 
   // Update the docs pane.
   docsLinkDemoName.textContent = name;


### PR DESCRIPTION
@bryanbraun 

Adding CodePen edit links, with the look/feel of the `about` link on the preview pane.

Moved the source pane down a bit from `1.5em to 2.5em` (padding-top). 
Added the CodePen Links to edit in `editLinks.js`