### PR TITLE
make the mojs example shorter

### DIFF
--- a/examples/mojs/script.js
+++ b/examples/mojs/script.js
@@ -1,13 +1,9 @@
 var ball = new mojs.Shape({
-  shape:    'circle',
-  fill:     '#613961',
-  radius:   25,
-  top:      33,
-  left:     33,
-  y:        { 0 : 160 },
-  duration: 575,
-  repeat:   1,
-  easing:   'quad.in',
-  isYoyo:   true,
-  onComplete () { ball.replay(); }
+  radius:    25,
+  y:         { '-80' : 80 },
+  duration:  575,
+  easing:    'quad.in',
+  isYoyo:    true,
+  repeat:    99999
 }).play();
+


### PR DESCRIPTION
Since the other examples use CSS to style the ball, I thought it would be fare to reduce the styles of the mojs  and stick with the default ones, so the cod snippet became much shorter. We still have the `radius: 25` styles there and I probably will change the example to work with `html div` as other’s do later. 