### PR TITLE
Added local http server to packages.json

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -18,7 +18,7 @@ When in doubt on how to organize your example, start by copying the `examples/te
 
 1. Clone the project down to your computer.
 2. From the project folder, run `npm install` in your terminal.
-3. Start a [local static server](https://gist.github.com/willurd/5720255). For example, if you're using a Mac with python installed, you can run `python -m SimpleHTTPServer 8000` in your terminal and go to `localhost:8000` in your browser to see the site.
+3. Start a local static server with `npm start` in your terminal and go to `localhost:8080` in your browser to see the site.
 4. Make file changes.
 5. Run `npm run build` to build the assets, and refresh your browser to see the changes.
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:js": "browserify site/js/app.js -o site/assets/bundle.js -t [ babelify --presets [es2015] ]",
     "build:css": "postcss --use stylelint --use postcss-import --postcss-import.path 'node_modules/prismjs/themes' --use postcss-cssnext --use postcss-reporter -o site/assets/styles.css site/css/*.css",
     "watch": "postcss --watch --use stylelint --use postcss-import --postcss-import.path 'node_modules/prismjs/themes' --use postcss-cssnext --use postcss-reporter -o site/assets/styles.css site/css/*.css",
-    "start": "node_modules/.bin/http-server ."
+    "start": "http-server ."
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build": "npm run build:css && npm run build:js",
     "build:js": "browserify site/js/app.js -o site/assets/bundle.js -t [ babelify --presets [es2015] ]",
     "build:css": "postcss --use stylelint --use postcss-import --postcss-import.path 'node_modules/prismjs/themes' --use postcss-cssnext --use postcss-reporter -o site/assets/styles.css site/css/*.css",
-    "watch": "postcss --watch --use stylelint --use postcss-import --postcss-import.path 'node_modules/prismjs/themes' --use postcss-cssnext --use postcss-reporter -o site/assets/styles.css site/css/*.css"
+    "watch": "postcss --watch --use stylelint --use postcss-import --postcss-import.path 'node_modules/prismjs/themes' --use postcss-cssnext --use postcss-reporter -o site/assets/styles.css site/css/*.css",
+    "start": "node_modules/.bin/http-server ."
   },
   "repository": {
     "type": "git",
@@ -34,6 +35,7 @@
     "babel-preset-es2015": "^6.9.0",
     "babelify": "^7.3.0",
     "browserify": "^13.0.1",
+    "http-server": "^0.9.0",
     "postcss": "^5.0.21",
     "postcss-cli": "^2.5.2",
     "postcss-cssnext": "^2.7.0",


### PR DESCRIPTION
Addressing the issue #15.

Added `http-server` as a development dependency, updated `contributing.md` and added a script to package.json to run it.

I added it as `npm run server` initially, but Node threw a warning message:

```
npm WARN bouncy-ball@1.0.0 scripts['server'] should probably be scripts['start'].
```

so changed it accordingly. Now development server can be started running `npm start`