### PR TITLE
fix: D3 demo: ball starts at the bottom moving upwards

### DIFF
--- a/examples/d3/script.js
+++ b/examples/d3/script.js
@@ -7,7 +7,7 @@ svg = d3.select('body')
         .append('g')
         .attr('transform', 'translate(25,25)');
 
-ball = svg.append("circle")
+ball = svg.append('circle')
           .attr('r', 25)
           .attr('fill', '#FF7B39');
 
@@ -15,12 +15,12 @@ function bounce() {
   ball
     .transition()
     .duration(575)
-    .ease(d3.easeQuadIn)
-    .attr('cy', 160)
-    .transition()
-    .duration(575)
     .ease(d3.easeQuadOut)
     .attr('cy', 0)
+    .transition()
+    .duration(575)
+    .ease(d3.easeQuadIn)
+    .attr('cy', 160)
     .on('end', bounce);
 }
 


### PR DESCRIPTION
@bryanbraun This fixes the issue where the demo for D3 where the ball was starting at the bottom rather than the top.