### PR TITLE
fix: React demo not working in Firefox.

### DIFF
--- a/examples/react/script-compiled.js
+++ b/examples/react/script-compiled.js
@@ -79,7 +79,7 @@ var QuadBounce = function (_React$Component) {
   _createClass(QuadBounce, [{
     key: 'componentWillMount',
     value: function componentWillMount() {
-      this.setState({ interval: setInterval(this.updateValue) });
+      this.setState({ interval: setInterval(this.updateValue, 20) });
     }
   }, {
     key: 'componentWillUnmount',

--- a/examples/react/script.js
+++ b/examples/react/script.js
@@ -38,7 +38,7 @@ class QuadBounce extends React.Component {
   }
 
   componentWillMount() {
-    this.setState({ interval: setInterval(this.updateValue) });
+    this.setState({ interval: setInterval(this.updateValue, 20) });
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
This fixes an issue where the React demo wasn't working properly in Firefox. I guess Firefox doesn't like the omission of a `rate` param.