### PR TITLE
🐛 fix: explicitly muted for autoplay on iOS

### DIFF
--- a/examples/video/index.html
+++ b/examples/video/index.html
@@ -1,4 +1,4 @@
-<video width="50" height="210" autoplay loop playsinline>
+<video width="50" height="210" autoplay muted loop playsinline>
   <source src="video.mp4" type="video/mp4">
   <source src="video.webm" type="video/webm">
   <source src="video.ogg" type="video/ogg">


### PR DESCRIPTION
From [New `<video>` Policies for iOS](https://webkit.org/blog/6784/new-video-policies-for-ios/):

> * `<video>` elements will be allowed to `autoplay` without a user gesture if their source media contains no audio tracks.
> * `<video muted>` elements will also be allowed to autoplay without a user gesture.

It's non-obvious that the files in the demo may or may not have audio tracks, so it may be better to make it explicit. A comment explaining this may also be helpful; what do you think?