### PR TITLE
feat(accessibility): enable tab navigation with focus states.

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
   <link rel="stylesheet" href="site/assets/styles.css">
 </head>
 
-<body>
+<body class="no-focus">
   <header class="header">
     <h1 class="title">Bouncy Ball</h1>
     <p class="description">Comparing web animation techniques by showing how to bounce a ball with each one.</p>
@@ -29,46 +29,26 @@
     </a>
   </header>
   <form class="selection-bar">
-    <input type="radio" id="vanilla-js" name="approaches" checked="true" />
-    <label for="vanilla-js" class="label label-vanillajs">Vanilla JS</label>
-    <input type="radio" id="css" name="approaches" />
-    <label for="css" class="label label-css">CSS</label>
-    <input type="radio" id="css-step" name="approaches" />
-    <label for="css-step" class="label label-cssstep">CSS (step)</label>
-    <input type="radio" id="jquery" name="approaches" />
-    <label for="jquery" class="label label-jquery">jQuery</label>
-    <input type="radio" id="greensock" name="approaches" />
-    <label for="greensock" class="label label-greensock">GreenSock</label>
-    <input type="radio" id="velocity" name="approaches" />
-    <label for="velocity" class="label label-velocity">Velocity</label>
-    <input type="radio" id="web-animations-api" name="approaches" />
-    <label for="web-animations-api" class="label label-webanimations">Web Animations API</label>
-    <input type="radio" id="p5" name="approaches" />
-    <label for="p5" class="label label-p5">P5.js</label>
-    <input type="radio" id="smil" name="approaches" />
-    <label for="smil" class="label label-smil">SMIL</label>
-    <input type="radio" id="mojs" name="approaches" />
-    <label for="mojs" class="label label-mojs">mo.js</label>
-    <input type="radio" id="anime" name="approaches" />
-    <label for="anime" class="label label-anime">anime.js</label>
-    <input type="radio" id="react" name="approaches" />
-    <label for="react" class="label label-react">React</label>
-    <input type="radio" id="d3" name="approaches" />
-    <label for="d3" class="label label-d3">D3</label>
-    <input type="radio" id="animated-gif" name="approaches" />
-    <label for="animated-gif" class="label label-gif">Animated Gif</label>
-    <input type="radio" id="video" name="approaches" />
-    <label for="video" class="label label-video">Video</label>
-    <input type="radio" id="matter-js" name="approaches" />
-    <label for="matter-js" class="label label-matterjs">Matter.js</label>
-    <input type="radio" id="webgl" name="approaches" />
-    <label for="webgl" class="label label-webgl">WebGL</label>
-    <input type="radio" id="flash" name="approaches" />
-    <label for="flash" class="label label-flash">Flash</label>
-    <input type="radio" id="popmotion" name="approaches" />
-    <label for="popmotion" class="label label-popmotion">Popmotion</label>
-    <input type="radio" id="lottie" name="approaches" />
-    <label for="lottie" class="label label-lottie">Lottie</label>
+    <a href="#vanilla-js" id="vanilla-js" class="nav-button button-vanillajs is-active">Vanilla JS</a>
+    <a href="#css" id="css" class="nav-button button-css">CSS</a>
+    <a href="#css-step" id="css-step" class="nav-button button-cssstep">CSS (step)</a>
+    <a href="#jquery" id="jquery" class="nav-button button-jquery">jQuery</a>
+    <a href="#greensock" id="greensock" class="nav-button button-greensock">GreenSock</a>
+    <a href="#velocity" id="velocity" class="nav-button button-velocity">Velocity</a>
+    <a href="#web-animations-api" id="web-animations-api" class="nav-button button-webanimations">Web Animations API</a>
+    <a href="#p5" id="p5" class="nav-button button-p5">P5.js</a>
+    <a href="#smil" id="smil" class="nav-button button-smil">SMIL</a>
+    <a href="#mojs" id="mojs" class="nav-button button-mojs">mo.js</a>
+    <a href="#anime" id="anime" class="nav-button button-anime">anime.js</a>
+    <a href="#react" id="react" class="nav-button button-react">React</a>
+    <a href="#d3" id="d3" class="nav-button button-d3">D3</a>
+    <a href="#animated-gif" id="animated-gif" class="nav-button button-gif">Animated Gif</a>
+    <a href="#video" id="video" class="nav-button button-video">Video</a>
+    <a href="#matter-js" id="matter-js" class="nav-button button-matterjs">Matter.js</a>
+    <a href="#webgl" id="webgl" class="nav-button button-webgl">WebGL</a>
+    <a href="#flash" id="flash" class="nav-button button-flash">Flash</a>
+    <a href="#popmotion" id="popmotion" class="nav-button button-popmotion">Popmotion</a>
+    <a href="#lottie" id="lottie" class="nav-button button-lottie">Lottie</a>
   </form>
   <div class="panes">
     <div class="docs-toggle">

--- a/site/assets/bundle.js
+++ b/site/assets/bundle.js
@@ -12795,22 +12795,22 @@ var toggleDocs = require('./toggleDocs');
 
 function init() {
   // DOM queries and a URL lookup.
-  var options = document.querySelectorAll('input[type="radio"]');
+  var options = document.querySelectorAll('.selection-bar .nav-button');
   var unsupportedLink = document.querySelector('.unsupported-details');
   var docsToggleLink = document.querySelector('.docs-toggle-link');
   var hashOption = window.location.hash;
 
   // Pre-select an option, if it is found in the URL fragment.
   if (hashOption) {
-    document.querySelector('input[checked]').removeAttribute('checked');
-    document.getElementById(hashOption.slice(1)).setAttribute('checked', true);
+    document.querySelector('.is-active').classList.remove('is-active');
+    document.getElementById(hashOption.slice(1)).classList.add('is-active');
   }
 
   updatePanes();
 
   // Set listeners for future updates:
   options.forEach(function (option) {
-    option.addEventListener('change', updatePanes);
+    option.addEventListener('click', updatePanes);
   });
   docsToggleLink.addEventListener('click', toggleDocs);
   unsupportedLink.addEventListener('click', toggleDocs);
@@ -12825,6 +12825,14 @@ module.exports = { init: init };
 //   eslint-disable-next-line no-unused-vars
 var Modernizr = require('./vendor/modernizr-custom');
 var App = require('./app');
+
+// outline.js replacement that handles outline styling in our stylesheets.
+document.addEventListener('mousedown', function () {
+  return document.body.classList.add('no-focus');
+});
+document.addEventListener('keydown', function () {
+  return document.body.classList.remove('no-focus');
+});
 
 App.init();
 
@@ -12967,8 +12975,19 @@ function highlightSource() {
  * Updates the preview & source panes based to match the currently selected option.
  */
 function updatePanes(event) {
-  selected = document.querySelector('input[type="radio"]:checked');
-  var name = selected.nextElementSibling.textContent;
+  if (event && event.type === 'click') {
+    // If a click triggered this function, we'll need to change .is-active
+    // and update the url (these don't need to be done when this function
+    // is run on the initial page load).
+    document.querySelector('.is-active').classList.remove('is-active');
+    event.currentTarget.classList.add('is-active');
+
+    window.location.hash = selected.id;
+  }
+
+  selected = document.querySelector('.is-active');
+
+  var name = selected.textContent;
   var srcFileName = selected.id === 'css' ? 'styles.css' : selected.id === 'css-step' ? 'styles.css' : selected.id === 'smil' ? 'image.svg' : selected.id === 'video' ? 'index.html' : selected.id === 'flash' ? 'index.html' : selected.id === 'animated-gif' ? 'index.html' : 'script.js';
 
   var demoFileName = selected.id === 'smil' ? 'image.svg' : 'index.html';
@@ -12977,12 +12996,6 @@ function updatePanes(event) {
   var srcUrl = 'examples/' + selected.id + '/' + srcFileName;
   var demoUrl = 'examples/' + selected.id + '/' + demoFileName;
   var docsUrl = 'examples/' + selected.id + '/readme.md';
-
-  // Update the page URL, when an option is changed.
-  // We only do this on the change event to prevent hash updates on initial page load.
-  if (event && event.type === 'change') {
-    window.location.hash = selected.id;
-  }
 
   // Update the source pane (scroll it to the top, and get the new source).
   srcPreEl.scrollTop = 0;

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -148,6 +148,18 @@ body {
 iframe[scrolling='no'] {
   overflow: hidden;
 }
+/*
+  We like focus rings, but only when a person is tabbing (not clicking).
+  Thus, we scope all focus ring suppression to a "no-focus" class, which
+  is added to the body tag when a person is clicking, and removed when a
+  person is tabbing. Same idea as https://github.com/lindsayevans/outline.js
+*/
+.no-focus :focus {
+  outline: 0;
+}
+.no-focus ::-moz-focus-inner {
+  border: 0;
+}
 .header {
   text-align: center;
   padding: 0 42px;
@@ -217,93 +229,97 @@ iframe[scrolling='no'] {
 		padding-bottom: 16px;
 	}
   }
-.selection-bar > label {
-	text-align: center;
-	list-style-type: none;
-	font-size: 14px;
-	padding: 4px 9px;
-	margin: 4px;
-	border-radius: 16px;
-	background-color: white;
-	cursor: pointer;
-	box-shadow: 0 1px 6px -3px black;
+.nav-button {
+  text-decoration: none;
+  text-align: center;
+  list-style-type: none;
+  font-family: 'Source Sans Pro', Verdana, sans-serif;
+  font-size: 14px;
+  padding: 4px 9px;
+  margin: 4px;
+  border: 0;
+  border-radius: 16px;
+  background-color: white;
+  cursor: pointer;
+  box-shadow: 0 1px 6px -3px black
 }
 @media (min-width: 500px) {
-	.selection-bar > label {
+	.nav-button {
 		font-size: 16px;
 		padding: 6px 12px;
 	}
+  }
+.nav-button:link {
+	color: black;
 }
-.selection-bar > label:hover {
+.nav-button:visited {
+	color: black;
+}
+.nav-button:hover {
 	background-color: #111111;
 	color: white;
 }
-.selection-bar input[type="radio"] {
-	display: none;
+.nav-button.is-active {
+	background-color: #111111;/* library-specific colors *//* stylelint-disable *//* stylelint-enable */
 }
-.selection-bar input[type="radio"]:checked {/* library-specific colors *//* stylelint-disable *//* stylelint-enable */
-}
-.selection-bar input[type="radio"]:checked + label {
-	background-color: #111111;
-}
-.selection-bar input[type="radio"]:checked + .label-matterjs {
+.nav-button.is-active.button-matterjs {
 	color: #76F09B;
 }
-.selection-bar input[type="radio"]:checked + .label-greensock {
+.nav-button.is-active.button-greensock {
 	color: #88CE02;
 }
-.selection-bar input[type="radio"]:checked + .label-vanillajs {
+.nav-button.is-active.button-vanillajs {
 	color: #F0DB4F;
 }
-.selection-bar input[type="radio"]:checked + .label-smil {
+.nav-button.is-active.button-smil {
 	color: #FFB13B;
 }
-.selection-bar input[type="radio"]:checked + .label-d3 {
+.nav-button.is-active.button-d3 {
 	color: #FF7B39;
 }
-.selection-bar input[type="radio"]:checked + .label-p5 {
+.nav-button.is-active.button-p5 {
 	color: #EC245E;
 }
-.selection-bar input[type="radio"]:checked + .label-webanimations {
+.nav-button.is-active.button-webanimations {
 	color: #E44D26;
 }
-.selection-bar input[type="radio"]:checked + .label-gif {
+.nav-button.is-active.button-gif {
 	color: #EE88E3;
 }
-.selection-bar input[type="radio"]:checked + .label-anime {
+.nav-button.is-active.button-anime {
 	color: #AE27E7;
 }
-.selection-bar input[type="radio"]:checked + .label-mojs {
+.nav-button.is-active.button-mojs {
 	color: #613961;
 }
-.selection-bar input[type="radio"]:checked + .label-jquery {
+.nav-button.is-active.button-jquery {
 	color: #0769AD;
 }
-.selection-bar input[type="radio"]:checked + .label-css {
+.nav-button.is-active.button-css {
 	color: #16A1DC;
 }
-.selection-bar input[type="radio"]:checked + .label-react {
+.nav-button.is-active.button-react {
 	color: #00CFFF;
 }
-.selection-bar input[type="radio"]:checked + .label-velocity {
+.nav-button.is-active.button-velocity {
 	color: #FFFFFF;
 }
-.selection-bar input[type="radio"]:checked + .label-video {
+.nav-button.is-active.button-video {
 	color: #CFD1AD;
 }
-.selection-bar input[type="radio"]:checked + .label-cssstep {
+.nav-button.is-active.button-cssstep {
 	color: #808080;
 }
-.selection-bar input[type="radio"]:checked + .label-webgl {
+.nav-button.is-active.button-webgl {
 	color: #AAAAAA;
 }
-.selection-bar input[type="radio"]:checked + .label-flash {
+.nav-button.is-active.button-flash {
 	color: #FF00FF;
 }
-.selection-bar input[type="radio"]:checked + .label-popmotion {
+.nav-button.is-active.button-popmotion {
 	color: #FF1C68;
 }
-.selection-bar input[type="radio"]:checked + .label-lottie {
+.nav-button.is-active.button-lottie {
 	color: #00E3C7;
 }
 .demo-frame {
@@ -420,7 +436,6 @@ iframe[scrolling='no'] {
   padding: 0;
   text-decoration: underline;
   cursor: pointer;
-  outline: none;
 }
 .docs-toggle-link_is-less::before {
   content: 'Less ';

--- a/site/css/styles.css
+++ b/site/css/styles.css
@@ -62,6 +62,19 @@ iframe[scrolling='no'] {
   overflow: hidden;
 }
 
+/*
+  We like focus rings, but only when a person is tabbing (not clicking).
+  Thus, we scope all focus ring suppression to a "no-focus" class, which
+  is added to the body tag when a person is clicking, and removed when a
+  person is tabbing. Same idea as https://github.com/lindsayevans/outline.js
+*/
+.no-focus :focus {
+  outline: 0;
+}
+.no-focus ::-moz-focus-inner {
+  border: 0;
+}
+
 .header {
   text-align: center;
   padding: 0 42px;
@@ -113,62 +126,67 @@ iframe[scrolling='no'] {
     padding-top: 16px;
     padding-bottom: 16px;
   }
+}
 
-  & > label {
-    text-align: center;
-    list-style-type: none;
-    font-size: 14px;
-    padding: 4px 9px;
-    margin: 4px;
-    border-radius: 16px;
-    background-color: white;
-    cursor: pointer;
-    box-shadow: 0 1px 6px -3px black;
+.nav-button {
+  text-decoration: none;
+  text-align: center;
+  list-style-type: none;
+  font-family: var(--copyFont);
+  font-size: 14px;
+  padding: 4px 9px;
+  margin: 4px;
+  border: 0;
+  border-radius: 16px;
+  background-color: white;
+  cursor: pointer;
+  box-shadow: 0 1px 6px -3px black;
 
-    @media (--midphone-plus) {
-      font-size: 16px;
-      padding: 6px 12px;
-    }
-
-    &:hover {
-      background-color: var(--previewDark);
-      color: white;
-    }
+  @media (--midphone-plus) {
+    font-size: 16px;
+    padding: 6px 12px;
   }
 
-  & input[type="radio"] {
-    display: none;
+  &:link {
+    color: black;
+  }
 
-    &:checked {
-      & + label {
-        background-color: var(--previewDark);
-      }
+  &:visited {
+    color: black;
+  }
 
-      /* library-specific colors */
+  &:hover {
+    background-color: var(--previewDark);
+    color: white;
+  }
 
-      /* stylelint-disable */
-      & + .label-matterjs      { color: #76F09B; }
-      & + .label-greensock     { color: #88CE02; }
-      & + .label-vanillajs     { color: #F0DB4F; }
-      & + .label-smil          { color: #FFB13B; }
-      & + .label-d3            { color: #FF7B39; }
-      & + .label-p5            { color: #EC245E; }
-      & + .label-webanimations { color: #E44D26; }
-      & + .label-gif           { color: #EE88E3; }
-      & + .label-anime         { color: #AE27E7; }
-      & + .label-mojs          { color: #613961; }
-      & + .label-jquery        { color: #0769AD; }
-      & + .label-css           { color: #16A1DC; }
-      & + .label-react         { color: #00CFFF; }
-      & + .label-velocity      { color: #FFFFFF; }
-      & + .label-video         { color: #CFD1AD; }
-      & + .label-cssstep       { color: #808080; }
-      & + .label-webgl         { color: #AAAAAA; }
-      & + .label-flash         { color: #FF00FF; }
-      & + .label-popmotion     { color: #FF1C68; }
-      & + .label-lottie        { color: #00E3C7; }
-      /* stylelint-enable */
-    }
+  &.is-active {
+    background-color: var(--previewDark);
+
+    /* library-specific colors */
+
+    /* stylelint-disable */
+    &.button-matterjs      { color: #76F09B; }
+    &.button-greensock     { color: #88CE02; }
+    &.button-vanillajs     { color: #F0DB4F; }
+    &.button-smil          { color: #FFB13B; }
+    &.button-d3            { color: #FF7B39; }
+    &.button-p5            { color: #EC245E; }
+    &.button-webanimations { color: #E44D26; }
+    &.button-gif           { color: #EE88E3; }
+    &.button-anime         { color: #AE27E7; }
+    &.button-mojs          { color: #613961; }
+    &.button-jquery        { color: #0769AD; }
+    &.button-css           { color: #16A1DC; }
+    &.button-react         { color: #00CFFF; }
+    &.button-velocity      { color: #FFFFFF; }
+    &.button-video         { color: #CFD1AD; }
+    &.button-cssstep       { color: #808080; }
+    &.button-webgl         { color: #AAAAAA; }
+    &.button-flash         { color: #FF00FF; }
+    &.button-popmotion     { color: #FF1C68; }
+    &.button-lottie        { color: #00E3C7; }
+    /* stylelint-enable */
   }
 }
 
@@ -271,7 +289,6 @@ iframe[scrolling='no'] {
   padding: 0;
   text-decoration: underline;
   cursor: pointer;
-  outline: none;
 }
 
 .docs-toggle-link_is-less::before {

--- a/site/js/app.js
+++ b/site/js/app.js
@@ -3,22 +3,22 @@ const toggleDocs = require('./toggleDocs');
 
 function init() {
   // DOM queries and a URL lookup.
-  const options = document.querySelectorAll('input[type="radio"]');
+  const options = document.querySelectorAll('.selection-bar .nav-button');
   const unsupportedLink = document.querySelector('.unsupported-details');
   const docsToggleLink = document.querySelector('.docs-toggle-link');
   const hashOption = window.location.hash;
 
   // Pre-select an option, if it is found in the URL fragment.
   if (hashOption) {
-    document.querySelector('input[checked]').removeAttribute('checked');
-    document.getElementById(hashOption.slice(1)).setAttribute('checked', true);
+    document.querySelector('.is-active').classList.remove('is-active');
+    document.getElementById(hashOption.slice(1)).classList.add('is-active');
   }
 
   updatePanes();
 
   // Set listeners for future updates:
   options.forEach((option) => {
-    option.addEventListener('change', updatePanes);
+    option.addEventListener('click', updatePanes);
   });
   docsToggleLink.addEventListener('click', toggleDocs);
   unsupportedLink.addEventListener('click', toggleDocs);

--- a/site/js/index.js
+++ b/site/js/index.js
@@ -3,4 +3,8 @@
 const Modernizr = require('./vendor/modernizr-custom');
 const App = require('./app');
 
+// outline.js replacement that handles outline styling in our stylesheets.
+document.addEventListener('mousedown', () => document.body.classList.add('no-focus'));
+document.addEventListener('keydown', () => document.body.classList.remove('no-focus'));
+
 App.init();

--- a/site/js/updatePanes.js
+++ b/site/js/updatePanes.js
@@ -84,8 +84,19 @@ function highlightSource() {
  * Updates the preview & source panes based to match the currently selected option.
  */
 function updatePanes(event) {
-  selected = document.querySelector('input[type="radio"]:checked');
-  const name = selected.nextElementSibling.textContent;
+  if (event && event.type === 'click') {
+    // If a click triggered this function, we'll need to change .is-active
+    // and update the url (these don't need to be done when this function
+    // is run on the initial page load).
+    document.querySelector('.is-active').classList.remove('is-active');
+    event.currentTarget.classList.add('is-active');
+
+    window.location.hash = selected.id;
+  }
+
+  selected = document.querySelector('.is-active');
+
+  const name = selected.textContent;
   const srcFileName = (selected.id === 'css') ? 'styles.css' :
                       (selected.id === 'css-step') ? 'styles.css' :
                       (selected.id === 'smil') ? 'image.svg' :
@@ -99,12 +110,6 @@ function updatePanes(event) {
   const srcUrl = `examples/${selected.id}/${srcFileName}`;
   const demoUrl = `examples/${selected.id}/${demoFileName}`;
   const docsUrl = `examples/${selected.id}/readme.md`;
-
-  // Update the page URL, when an option is changed.
-  // We only do this on the change event to prevent hash updates on initial page load.
-  if (event && event.type === 'change') {
-    window.location.hash = selected.id;
-  }
 
   // Update the source pane (scroll it to the top, and get the new source).
   srcPreEl.scrollTop = 0;


### PR DESCRIPTION
This required refactoring away from using radio buttons as the
navigation items.

I included a '.no-focus' body class to prevent focus rings on click
for the "docs toggle." It also addressed a weird situation where an
initial page load with a nav-item's id in the url caused it to show a
focus ring by default (which I didn't want). I still don't know why it
was doing that, but I think it must be some browser's defaut behavior
when the "jump to id" element is a link.

Fixes sparkbox/bouncy-ball#62