### PR TITLE
A11y color contrast

### DIFF
--- a/examples/anime/index.html
+++ b/examples/anime/index.html
@@ -5,17 +5,17 @@
   <title>Bouncy Ball - Comparing Web Animation Techniques - anime.js</title>
   <link rel="stylesheet" href="../shared-styles.css">
   <style>
-    #ball {
+    ball {
       display: block;
       width: 50px;
       height: 50px;
       border-radius: 50%;
-      background-color: #ae27e7;
+      background-color: var(--anime);
     }
   </style>
 </head>
 <body>
-  <div id="ball"></div>
+  <ball></ball>
   <script src="anime.3.2.0.min.js"></script>
   <script src="script.js"></script>
 </body>

--- a/examples/anime/script.js
+++ b/examples/anime/script.js
@@ -3,7 +3,7 @@ const { anime } = window;
 function bounce() {
   const bounceUp = anime({
     autoplay: false, // We don't want to immediately start the animation
-    targets: '#ball', // target the div '#ball'
+    targets: 'ball', // target the <ball></ball>
     translateY: {
       value: ['160px', '0px'], // When bouncing up, start at 160px and end at 0px
       duration: 575,
@@ -14,7 +14,7 @@ function bounce() {
 
   const bounceDown = anime({
     autoplay: false, // See similar comments above
-    targets: '#ball',
+    targets: 'ball',
     translateY: {
       value: ['0px', '160px'], // When bouncing down, start at 0px and end at 160px
       duration: 575,

--- a/examples/css/styles.css
+++ b/examples/css/styles.css
@@ -3,7 +3,7 @@ ball {
   width: 50px;
   height: 50px;
   border-radius: 50%;
-  background-color: #16A1DC;
+  background-color: var(--css);
 
   /* animation properties */
   animation-name: bounce;

--- a/examples/d3/script.js
+++ b/examples/d3/script.js
@@ -1,4 +1,5 @@
 var svg, ball;
+var ballColor = getComputedStyle(document.documentElement).getPropertyValue('--d3');
 
 svg = d3.select('body')
         .append('svg')
@@ -9,7 +10,7 @@ svg = d3.select('body')
 
 ball = svg.append('circle')
           .attr('r', 25)
-          .attr('fill', '#FF7B39');
+          .attr('fill', ballColor);
 
 function bounce() {
   ball

--- a/examples/greensock/index.html
+++ b/examples/greensock/index.html
@@ -10,7 +10,7 @@
       width: 50px;
       height: 50px;
       border-radius: 50%;
-      background-color: #88CE02;
+      background-color: var(--greensock);
     }
   </style>
 </head>

--- a/examples/jquery/index.html
+++ b/examples/jquery/index.html
@@ -15,7 +15,7 @@
       width: 50px;
       height: 50px;
       border-radius: 50%;
-      background-color: #0769AD;
+      background-color: var(--jquery);
       position: absolute;
       will-change: top;
     }

--- a/examples/matter-js/script.js
+++ b/examples/matter-js/script.js
@@ -14,6 +14,7 @@ var render = Render.create({
       background: '#111'
     }
 });
+var ballColor = getComputedStyle(document.documentElement).getPropertyValue('--matterjs');
 
 // Use a many-sided polygon as a ball, to ensure 100% elasticity.
 // See https://github.com/liabru/matter-js/issues/256
@@ -23,7 +24,7 @@ var ball = Bodies.polygon(33, 25, 30, 25, {
   frictionAir: 0,
   frictionStatic: 0,
   inertia: Infinity,
-  render: { fillStyle: '#76F09B' }
+  render: { fillStyle: ballColor }
 });
 var ground = Bodies.rectangle(33, 225, 66, 1, {
   isStatic: true,

--- a/examples/mojs/index.html
+++ b/examples/mojs/index.html
@@ -4,6 +4,11 @@
   <meta charset="UTF-8">
   <title>Bouncy Ball - Comparing Web Animation Techniques - mo.js</title>
   <link rel="stylesheet" href="../shared-styles.css">
+  <style>
+    [data-name="mojs-shape"] ellipse {
+      fill: var(--mojs);
+    }
+  </style>
 </head>
 <body>
   <script src="mo-0.288.2.min.js"></script>

--- a/examples/mojs/script.js
+++ b/examples/mojs/script.js
@@ -1,6 +1,5 @@
 var ball = new mojs.Shape({
   shape:    'circle',
-  fill:     '#613961',
   radius:   25,
   top:      33,
   left:     33,

--- a/examples/p5/script.js
+++ b/examples/p5/script.js
@@ -2,10 +2,11 @@ var h = 575; // x vertex, half of total bounce duration
 var k = 160; // y vertex, total bounce height
 var a = -4 * k / Math.pow(h * 2, 2); // coefficient: -.000483932
 var ypos, start, time, timestamp;
+var ballColor = getComputedStyle(document.documentElement).getPropertyValue('--p5');
 
 function setup() {
   createCanvas(66, 226);
-  fill('#EC245E');
+  fill(ballColor);
   noStroke();
 }
 

--- a/examples/popmotion/index.html
+++ b/examples/popmotion/index.html
@@ -5,17 +5,17 @@
   <title>Bouncy Ball - Comparing Web Animation Techniques - Popmotion</title>
   <link rel="stylesheet" href="../shared-styles.css">
   <style>
-    #ball {
+    ball {
       display: block;
       width: 50px;
       height: 50px;
       border-radius: 50%;
-      background-color: #FF1C68;
+      background-color: var(--popmotion);
     }
   </style>
 </head>
 <body>
-  <div id="ball"></div>
+  <ball></ball>
   <script src="popmotion.8.7.5.global.min.js"></script>
   <script src="script.js"></script>
 </body>

--- a/examples/popmotion/script.js
+++ b/examples/popmotion/script.js
@@ -1,5 +1,5 @@
 const { styler, tween, easing } = popmotion;
-const ballStyler = styler(document.getElementById('ball'));
+const ballStyler = styler(document.querySelector('ball'));
 
 tween({
   to: 160,

--- a/examples/react/index.html
+++ b/examples/react/index.html
@@ -5,7 +5,14 @@
   <title>Bouncy Ball - Comparing Web Animation Techniques - React</title>
   <link rel="stylesheet" href="../shared-styles.css">
   <style>
-    /* insert demo-specific styles here */
+    #ball {
+      display: block;
+      position: absolute;
+      width: 50px;
+      height: 50px;
+      border-radius: 50%;
+      background-color: var(--react);
+    }
   </style>
 </head>
 <body>

--- a/examples/react/script.js
+++ b/examples/react/script.js
@@ -34,20 +34,10 @@ function useQuadBounce({
   return value;
 }
 
-// default ball style, CSS in JS
-const style = {
-  display: 'block',
-  position: 'absolute',
-  width: 50,
-  height: 50,
-  borderRadius: '50%',
-  backgroundColor: '#00CFFF',
-};
-
 function BouncyBall() {
   const y = useQuadBounce();
 
-  return <div style={{ ...style, transform: `translate3d(0, ${y}px, 0)` }} />;
+  return <div id="ball" style={{ transform: `translate3d(0, ${y}px, 0)` }} />;
 }
 
 ReactDOM.render(<BouncyBall />, document.getElementById('root'));

--- a/examples/shared-styles.css
+++ b/examples/shared-styles.css
@@ -1,4 +1,6 @@
-/* resets the document for all our demos */ 
+@import "../site/css/example-colors.css";
+
+/* resets the document for all our demos */
 body {
   background-color: #111;
 }

--- a/examples/smil/image.svg
+++ b/examples/smil/image.svg
@@ -2,11 +2,15 @@
   xmlns="http://www.w3.org/2000/svg"
   xmlns:xlink="http://www.w3.org/1999/xlink"
   width="66" height="226">
-
+  <style>
+    @import '../shared-styles.css';
+    circle {
+      fill: var(--smil);
+    }
+  </style>
   <circle
     class="ball"
-    cx="33" cy="33" r="25"
-    fill="#FFB13B">
+    cx="33" cy="33" r="25">
 
     <animateTransform
       attributeName="transform"

--- a/examples/vanilla-js/index.html
+++ b/examples/vanilla-js/index.html
@@ -11,7 +11,7 @@
       width: 50px;
       height: 50px;
       border-radius: 50%;
-      background-color: #F0DB4F;
+      background-color: var(--vanillajs);
 
       /* compensate for the opposite axis direction,
          and initialize the ball height at its peak. */

--- a/examples/velocity/index.html
+++ b/examples/velocity/index.html
@@ -10,7 +10,7 @@
       width: 50px;
       height: 50px;
       border-radius: 50%;
-      background-color: #fff;
+      background-color: var(--velocity);
       position: absolute;
     }
   </style>

--- a/examples/web-animations-api/index.html
+++ b/examples/web-animations-api/index.html
@@ -10,7 +10,7 @@
       width: 50px;
       height: 50px;
       border-radius: 50%;
-      background-color: #E44D26;
+      background-color: var(--webanimations);
       position: absolute;
     }
   </style>

--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
     <div class="pane preview-pane">
       <p class="unsupported" style="display: none">This technique is not supported in your browser.
         <a href="#" id="learn" class="unsupported-details">Learn more</a>.</p>
-      <iframe class="demo-frame" src="examples/vanilla-js/index.html" name="bouncy ball demo" frameborder="1" scrolling="no"></iframe>
+      <iframe class="demo-frame" src="examples/vanilla-js/index.html" name="bouncy ball demo" title="bouncy ball demo" frameborder="1" scrolling="no"></iframe>
     </div>
     <div class="pane source-pane">
       <pre><code class="language-javascript"></code></pre>

--- a/site/css/example-colors.css
+++ b/site/css/example-colors.css
@@ -1,0 +1,23 @@
+/* colors for navigation buttons and bouncy balls */
+:root {
+  --matterjs:      #76F09B;
+  --greensock:     #88CE02;
+  --vanillajs:     #F0DB4F;
+  --smil:          #FFB13B;
+  --d3:            #FF7B39;
+  --p5:            #EC245E;
+  --webanimations: #E44D26;
+  --gif:           #EE88E3;
+  --anime:         #AE27E7;
+  --mojs:          #613961;
+  --jquery:        #0769AD;
+  --css:           #16A1DC;
+  --react:         #00CFFF;
+  --velocity:      #FFFFFF;
+  --video:         #CFD1AD;
+  --cssstep:       #808080;
+  --webgl:         #AAAAAA;
+  --flash:         #FF00FF;
+  --popmotion:     #FF1C68;
+  --lottie:        #00E3C7;
+}

--- a/site/css/example-colors.css
+++ b/site/css/example-colors.css
@@ -1,16 +1,19 @@
-/* colors for navigation buttons and bouncy balls */
+/*
+  colors for navigation buttons and bouncy balls
+  ! make sure all colors meet WCAG AA standards for normal text
+*/
 :root {
   --matterjs:      #76F09B;
   --greensock:     #88CE02;
   --vanillajs:     #F0DB4F;
   --smil:          #FFB13B;
   --d3:            #FF7B39;
-  --p5:            #EC245E;
+  --p5:            #ED3166;
   --webanimations: #E44D26;
   --gif:           #EE88E3;
-  --anime:         #AE27E7;
-  --mojs:          #613961;
-  --jquery:        #0769AD;
+  --anime:         #FF4B4B;
+  --mojs:          #A668A6;
+  --jquery:        #0981D7;
   --css:           #16A1DC;
   --react:         #00CFFF;
   --velocity:      #FFFFFF;

--- a/site/css/styles.css
+++ b/site/css/styles.css
@@ -25,7 +25,7 @@
   --previewDark: #111111;
   --docsDark: #151515;
   --sourceDark: #1d1d1d;
-  --secondaryInfo: #49525a;
+  --secondaryInfo: #707e89;
 
   /* This matches a color from our prism-okaidia syntax highlighting theme */
   --linkYellow: #e6db74;

--- a/site/css/styles.css
+++ b/site/css/styles.css
@@ -2,6 +2,7 @@
  *** Imports (must be first) ***
  *******************************/
 @import "prism-okaidia";
+@import "./example-colors.css";
 
 
 /*******************************
@@ -166,26 +167,26 @@ iframe[scrolling='no'] {
     /* library-specific colors */
 
     /* stylelint-disable */
-    &.button-matterjs      { color: #76F09B; }
-    &.button-greensock     { color: #88CE02; }
-    &.button-vanillajs     { color: #F0DB4F; }
-    &.button-smil          { color: #FFB13B; }
-    &.button-d3            { color: #FF7B39; }
-    &.button-p5            { color: #EC245E; }
-    &.button-webanimations { color: #E44D26; }
-    &.button-gif           { color: #EE88E3; }
-    &.button-anime         { color: #AE27E7; }
-    &.button-mojs          { color: #613961; }
-    &.button-jquery        { color: #0769AD; }
-    &.button-css           { color: #16A1DC; }
-    &.button-react         { color: #00CFFF; }
-    &.button-velocity      { color: #FFFFFF; }
-    &.button-video         { color: #CFD1AD; }
-    &.button-cssstep       { color: #808080; }
-    &.button-webgl         { color: #AAAAAA; }
-    &.button-flash         { color: #FF00FF; }
-    &.button-popmotion     { color: #FF1C68; }
-    &.button-lottie        { color: #00E3C7; }
+    &.button-matterjs      { color: var(--matterjs); }
+    &.button-greensock     { color: var(--greensock); }
+    &.button-vanillajs     { color: var(--vanillajs); }
+    &.button-smil          { color: var(--smil); }
+    &.button-d3            { color: var(--d3); }
+    &.button-p5            { color: var(--p5); }
+    &.button-webanimations { color: var(--webanimations); }
+    &.button-gif           { color: var(--gif); }
+    &.button-anime         { color: var(--anime); }
+    &.button-mojs          { color: var(--mojs); }
+    &.button-jquery        { color: var(--jquery); }
+    &.button-css           { color: var(--css); }
+    &.button-react         { color: var(--react); }
+    &.button-velocity      { color: var(--velocity); }
+    &.button-video         { color: var(--video); }
+    &.button-cssstep       { color: var(--cssstep); }
+    &.button-webgl         { color: var(--webgl); }
+    &.button-flash         { color: var(--flash); }
+    &.button-popmotion     { color: var(--popmotion); }
+    &.button-lottie        { color: var(--lottie); }
     /* stylelint-enable */
   }
 }


### PR DESCRIPTION
### Changes
This updates all colors used in examples to meet AA WCAG standards for color contrast. Color changes mainly effect navigation buttons, but this also updates the text color used in the site footer.

- move colors for examples into variables and share between site and iframe css files
- update colors to meet AA contrast standards
- update examples to utilize new css variables where possible
- add title to demo iframe for a11y improvement

### Validation
- [ ] all examples should function correctly.
- [ ] all navigation buttons should pass color contrast AA standards
- [ ] color of bouncy balls in each example should match that of the relative nav buttons