### PR TITLE
refactor: simplify the JS around nav buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
     </a>
   </header>
   <div class="selection-bar">
-    <a href="#vanilla-js" id="vanilla-js" class="nav-button button-vanillajs is-active">Vanilla JS</a>
+    <a href="#vanilla-js" id="vanilla-js" class="nav-button button-vanillajs">Vanilla JS</a>
     <a href="#css" id="css" class="nav-button button-css">CSS</a>
     <a href="#css-step" id="css-step" class="nav-button button-cssstep">CSS (step)</a>
     <a href="#canvas" id="canvas" class="nav-button button-canvas">Canvas</a>

--- a/site/css/styles.css
+++ b/site/css/styles.css
@@ -183,32 +183,32 @@ code a {
   color: white;
 }
 
-.nav-button.is-active {
+.nav-button:target {
   background-color: var(--previewDark);
 }
 
 /* stylelint-disable */
-.button-matterjs.is-active      { color: var(--matterjs); }
-.button-greensock.is-active     { color: var(--greensock); }
-.button-vanillajs.is-active     { color: var(--vanillajs); }
-.button-smil.is-active          { color: var(--smil); }
-.button-d3.is-active            { color: var(--d3); }
-.button-p5.is-active            { color: var(--p5); }
-.button-webanimations.is-active { color: var(--webanimations); }
-.button-gif.is-active           { color: var(--gif); }
-.button-anime.is-active         { color: var(--anime); }
-.button-mojs.is-active          { color: var(--mojs); }
-.button-jquery.is-active        { color: var(--jquery); }
-.button-css.is-active           { color: var(--css); }
-.button-react.is-active         { color: var(--react); }
-.button-velocity.is-active      { color: var(--velocity); }
-.button-video.is-active         { color: var(--video); }
-.button-cssstep.is-active       { color: var(--cssstep); }
-.button-webgl.is-active         { color: var(--webgl); }
-.button-flash.is-active         { color: var(--flash); }
-.button-popmotion.is-active     { color: var(--popmotion); }
-.button-lottie.is-active        { color: var(--lottie); }
-.button-canvas.is-active        { color: var(--canvas); }
+.button-matterjs:target      { color: var(--matterjs); }
+.button-greensock:target     { color: var(--greensock); }
+.button-vanillajs:target     { color: var(--vanillajs); }
+.button-smil:target          { color: var(--smil); }
+.button-d3:target            { color: var(--d3); }
+.button-p5:target            { color: var(--p5); }
+.button-webanimations:target { color: var(--webanimations); }
+.button-gif:target           { color: var(--gif); }
+.button-anime:target         { color: var(--anime); }
+.button-mojs:target          { color: var(--mojs); }
+.button-jquery:target        { color: var(--jquery); }
+.button-css:target           { color: var(--css); }
+.button-react:target         { color: var(--react); }
+.button-velocity:target      { color: var(--velocity); }
+.button-video:target         { color: var(--video); }
+.button-cssstep:target       { color: var(--cssstep); }
+.button-webgl:target         { color: var(--webgl); }
+.button-flash:target         { color: var(--flash); }
+.button-popmotion:target     { color: var(--popmotion); }
+.button-lottie:target        { color: var(--lottie); }
+.button-canvas:target        { color: var(--canvas); }
 /* stylelint-enable */
 
 .demo-frame {

--- a/site/js/index.js
+++ b/site/js/index.js
@@ -9,22 +9,16 @@ document.addEventListener('mousedown', () => document.body.classList.add('no-foc
 document.addEventListener('keydown', () => document.body.classList.remove('no-focus'));
 
 // DOM queries and a URL lookup.
-const options = document.querySelectorAll('.selection-bar .nav-button');
 const unsupportedLink = document.querySelector('.unsupported-details');
 const docsToggleLink = document.querySelector('.docs-toggle-link');
-const hashOption = window.location.hash;
 
-// Pre-select an option, if it is found in the URL fragment.
-if (hashOption) {
-  document.querySelector('.is-active').classList.remove('is-active');
-  document.getElementById(hashOption.slice(1)).classList.add('is-active');
+// Pre-select vanilla-js if no document fragment in url.
+if (!window.location.hash) {
+  window.location.hash = 'vanilla-js';
 }
 
 updatePanes();
 
-// Set listeners for future updates:
-options.forEach((option) => {
-  option.addEventListener('click', updatePanes);
-});
+window.addEventListener('hashchange', updatePanes);
 docsToggleLink.addEventListener('click', toggleDocs);
 unsupportedLink.addEventListener('click', toggleDocs);

--- a/site/js/updatePanes.js
+++ b/site/js/updatePanes.js
@@ -116,18 +116,8 @@ function highlightSource() {
 /**
  * Updates the preview & source panes based to match the currently selected option.
  */
-function updatePanes(event) {
-  if (event && event.type === 'click') {
-    // If a click triggered this function, we'll need to change .is-active
-    // and update the url (these don't need to be done when this function
-    // is run on the initial page load).
-    document.querySelector('.is-active').classList.remove('is-active');
-    event.currentTarget.classList.add('is-active');
-
-    window.location.hash = selected.id;
-  }
-
-  selected = document.querySelector('.is-active');
+function updatePanes() {
+  selected = document.querySelector(window.location.hash);
 
   const name = selected.textContent;
   const srcFileName =


### PR DESCRIPTION
The purpose of this is to simplify the site JS by styling the navigation via document fragment browser features.

- remove the class name toggle functionality
- utilize the css :target attribute for styling
- remove click listeners on all nav buttons
- listen for hashchange event to run updatePanes

### Validation
- [x] everything should still work