### PR TITLE
fix: motion one demo

### DIFF
--- a/examples/motion-one/script.js
+++ b/examples/motion-one/script.js
@@ -2,11 +2,11 @@ const ball = document.getElementsByTagName("ball");
 
 Motion.animate(
   ball,
-  { y: [160, 0] },
+  { y: [0, 160] },
   {
     duration: .575,
     repeat: Infinity,
-    direction: "alternate-reverse",
-    ease: "cubic-bezier(.6, 0.08, 0.8, .6)"
-  },
+    direction: "alternate",
+    easing: "cubic-bezier(.6, 0.08, 0.8, .6)"
+  }
 );


### PR DESCRIPTION
Seems like **motion one** example doesn't work as intended. The ball looks like it's floating rather than bouncing.

**ease** is not an option in **motion**, the correct name is **easing**, maybe the specs changed since #108 

I'm attaching gifs to compare, but it's much easier to see in the browser.
before | after
--- | ---
![motion before changes][old] | ![motion after changes][new]

[old]: https://user-images.githubusercontent.com/26126510/146511639-a2e13836-96d2-4eee-856e-f085afe59be1.gif
[new]: https://user-images.githubusercontent.com/26126510/146511641-d25f58bf-9993-4a6e-a9f1-4bdff0777b49.gif

