### PR TITLE
fix: ensure the matterjs bounce speed is consistent

### DIFF
--- a/examples/matter-js/script.js
+++ b/examples/matter-js/script.js
@@ -1,24 +1,30 @@
-var Engine = Matter.Engine,
-    Render = Matter.Render,
-    Bodies = Matter.Bodies,
-    World = Matter.World;
+const Engine = Matter.Engine,
+  Render = Matter.Render,
+  Runner = Matter.Runner,
+  Bodies = Matter.Bodies,
+  World = Matter.World;
 
-var engine = Engine.create();
-var render = Render.create({
-    element: document.body,
-    engine: engine,
-    options: {
-      width: 66,
-      height: 226,
-      wireframes: false,
-      background: '#111'
-    }
+const runner = Runner.create({
+  isFixed: true,
+  delta: 1000 / 120,
 });
-var ballColor = getComputedStyle(document.documentElement).getPropertyValue('--matterjs');
+const engine = Engine.create();
+const render = Render.create({
+  element: document.body,
+  engine: engine,
+  options: {
+    width: 66,
+    height: 226,
+    wireframes: false,
+    background: '#111'
+  }
+});
+const ballColor = getComputedStyle(document.documentElement).getPropertyValue('--matterjs');
+
 
 // Use a many-sided polygon as a ball, to ensure 100% elasticity.
 // See https://github.com/liabru/matter-js/issues/256
-var ball = Bodies.polygon(33, 25, 30, 25, {
+const ball = Bodies.polygon(33, 25, 30, 25, {
   restitution: 1,
   friction: 0,
   frictionAir: 0,
@@ -26,11 +32,11 @@ var ball = Bodies.polygon(33, 25, 30, 25, {
   inertia: Infinity,
   render: { fillStyle: ballColor }
 });
-var ground = Bodies.rectangle(33, 225, 66, 1, {
+const ground = Bodies.rectangle(33, 225, 66, 1, {
   isStatic: true,
   render: { fillStyle: '#111' }
 });
 
 World.add(engine.world, [ball, ground]);
-Engine.run(engine);
+Runner.run(runner, engine);
 Render.run(render);


### PR DESCRIPTION
Fixes sparkbox/bouncy-ball#113.

## Testing instructions:

1. Pull down this branch: 
    - It's easy with [gh](https://cli.github.com/manual/gh_pr_checkout): `gh pr checkout 114`
2. Install dependencies: `npm ci && npm run build`
3. Start the app: `npm run start`
4. In firefox, browse to `http://localhost:3000/#matter-js` and confirm that the ball bounces at the same speed as the other demos. Note: it's ok if the ball loses bounce height over time... that's captured in [a different issue](https://github.com/sparkbox/bouncy-ball/issues/110).

